### PR TITLE
Add client response

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -29,6 +29,9 @@ Let's start building a client for users resource in https://reqres.in/ service::
     {'page': 1, 'per_page': 3, 'total': 12, 'total_pages': 4, 'data': [{'id': 1, 'first_name': 'george', 'last_name': 'bluth', 'avatar': 'https://s3.amazonaws.com/uifaces/faces/twitter/calebogden/128.jpg'}, {'id': 2, 'first_name': 'lucille', 'last_name': 'bluth', 'avatar': 'https://s3.amazonaws.com/uifaces/faces/twitter/josephstein/128.jpg'}, {'id': 3, 'first_name': 'oscar', 'last_name': 'bluth', 'avatar': 'https://s3.amazonaws.com/uifaces/faces/twitter/olegpogodaev/128.jpg'}]}
     >>> response.headers
     {'Date': 'Sat, 15 Apr 2017 21:39:46 GMT', 'Content-Type': 'application/json; charset=utf-8', 'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'X-Powered-By': 'Express', 'Access-Control-Allow-Origin': '*', 'ETag': 'W/"1be-q96WkDv6JqfLvIPiRhzWJQ"', 'Server': 'cloudflare-nginx', 'CF-RAY': '35020f33aaf04a9c-GRU', 'Content-Encoding': 'gzip'}
+    >>> response.client_response.cookies
+    <RequestsCookieJar[Cookie(version=0, name='__cfduid', value='d85187baf0752d02c6836abf7fb0c426c1506866165', port=None, port_specified=False, domain='.reqres.in', domain_specified=True, domain_initial_dot=True, path='/', path_specified=True, secure=False, expires=1538402165, discard=False, comment=None, comment_url=None, rest={'HttpOnly': None}, rfc2109=False)]>
+
     >>> response.status_code
     200
     >>> # create action

--- a/simple_rest_client/models.py
+++ b/simple_rest_client/models.py
@@ -1,8 +1,8 @@
 from collections import namedtuple
 
 Request = namedtuple(
-    'Request', ['url', 'method', 'params', 'body', 'headers', 'timeout']
+    'Request', ['url', 'method', 'params', 'body', 'headers', 'timeout',]
 )
 Response = namedtuple(
-    'Response', ['url', 'method', 'body', 'headers', 'status_code']
+    'Response', ['url', 'method', 'body', 'headers', 'status_code', 'client_response']
 )

--- a/simple_rest_client/request.py
+++ b/simple_rest_client/request.py
@@ -34,7 +34,8 @@ def make_request(session, request):
         method=method,
         body=body,
         headers=client_response.headers,
-        status_code=client_response.status_code
+        status_code=client_response.status_code,
+        client_response=client_response
     )
     logger.debug(
         'operation=request_finished, request={!r}, response={!r}'.format(
@@ -64,7 +65,8 @@ async def make_async_request(session, request):
                 method=method,
                 body=body,
                 headers=dict(client_response.headers),
-                status_code=client_response.status
+                status_code=client_response.status,
+                client_response=client_response
             )
             logger.info(
                 'operation=request_finished, request={!r}, response={!r}'.format(

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -25,7 +25,7 @@ from simple_rest_client.models import Response
 def test_validate_response_server_error(status_code):
     response = Response(
         url='http://example.com', method='GET', body=None, headers={},
-        status_code=status_code
+        status_code=status_code, client_response=mock.Mock()
     )
     with pytest.raises(ServerError) as excinfo:
         validate_response(response)
@@ -37,7 +37,7 @@ def test_validate_response_server_error(status_code):
 def test_validate_response_client_error(status_code):
     response = Response(
         url='http://example.com', method='GET', body=None, headers={},
-        status_code=status_code
+        status_code=status_code, client_response=mock.Mock()
     )
     with pytest.raises(ClientError) as excinfo:
         validate_response(response)


### PR DESCRIPTION
I'm embedding the client_response in the Response object to be able to use requests response values directly.

My use case is I want to use the [link headers](http://docs.python-requests.org/en/master/user/advanced/#link-headers) functionality, right now I could import requests `parse_header_links` and use the already available headers in the Response, but thought it might be useful to expose the complete client_response

Just close the PR if it doesn't make sense :)