### PR TITLE
json.decoder.JSONDecodeError when processing empty server responses

### DIFF
--- a/simple_rest_client/request.py
+++ b/simple_rest_client/request.py
@@ -26,7 +26,10 @@ def make_request(session, request):
     if 'text' in content_type:
         body = client_response.text
     elif 'json' in content_type:
-        body = json.loads(client_response.text)
+        if client_response.text:
+            body = json.loads(client_response.text)
+        else:
+            body = client_response.content
     else:
         body = client_response.content
 


### PR DESCRIPTION
Hey, really like your lib and the elegant interface.

I encountered an exception (see below) when I received an empty response from the server, in this case a "204 NO CONTENT". The lib forwarded the empty response to JSON for decoding which raised the exception. As a quick fix, I added a check whether client_response.text is True. This works for me, for empty and non-empty responses.

The exception:
[...]
  File "/usr/local/lib/python3.5/dist-packages/simple_rest_client/resource.py", line 107, in action_method
    return make_request(self.session, request)
  File "/usr/local/lib/python3.5/dist-packages/simple_rest_client/decorators.py", line 39, in wrapper
    response = f(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/simple_rest_client/request.py", line 30, in make_request
    body = json.loads(client_response.text)
  File "/usr/local/lib/python3.5/dist-packages/json_encoder/json/__init__.py", line 229, in loads
    **kw
  File "/usr/lib/python3.5/json/__init__.py", line 332, in loads
    return cls(**kw).decode(s)
  File "/usr/lib/python3.5/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.5/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
