### PR TITLE
Fix api_root_url without trailing slash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
 # command to install dependencies
 install:
   - pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 # command to install dependencies
 install:
   - pip install -r requirements-dev.txt

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+0.5.3
+~~~~~
+
+* Fix api_root_url without trailing slash (thanks @dspechnikov).
+
 0.5.2
 ~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries',
     ],
     keywords='rest client http asyncio',

--- a/simple_rest_client/resource.py
+++ b/simple_rest_client/resource.py
@@ -72,7 +72,9 @@ class BaseResource:
 
         if self.append_slash and not url.endswith('/'):
             url += '/'
-        return urljoin(self.api_root_url, url)
+        if not self.api_root_url.endswith('/'):
+            self.api_root_url += '/'
+        return self.api_root_url + url
 
     def get_action_method(self, action_name):
         action = self.get_action(action_name)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -30,6 +30,16 @@ def test_base_resource_get_action_full_url_with_append_slash(base_resource):
     assert resource.get_action_full_url('destroy', 1) == 'http://example.com/users/1/'
 
 
+def test_base_resource_get_action_full_url_api_root_url_without_trailing_slash(base_resource):
+    resource = base_resource(api_root_url='http://example.com/v1', resource_name='users')
+    assert resource.get_action_full_url('list') == 'http://example.com/v1/users'
+    assert resource.get_action_full_url('create') == 'http://example.com/v1/users'
+    assert resource.get_action_full_url('retrieve', 1) == 'http://example.com/v1/users/1'
+    assert resource.get_action_full_url('update', 1) == 'http://example.com/v1/users/1'
+    assert resource.get_action_full_url('partial_update', 1) == 'http://example.com/v1/users/1'
+    assert resource.get_action_full_url('destroy', 1) == 'http://example.com/v1/users/1'
+
+
 def test_base_resource_get_action_full_url_with_action_not_found(base_resource):
     resource = base_resource(api_root_url='http://example.com', resource_name='users')
     with pytest.raises(ActionNotFound) as execinfo:


### PR DESCRIPTION
Issue: https://github.com/allisson/python-simple-rest-client/issues/11

Thanks @dspechnikov 👍 