### PR TITLE
Simplify httpx timeout handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 install:
   - pip install pip -U
   - pip install -r requirements-dev.txt

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Simple Rest Client
 
 ----
 
-Simple REST client for python 3.5+.
+Simple REST client for python 3.6+.
 
 
 How to install

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 Welcome to python-simple-rest-client's documentation!
 =====================================================
 
-Simple REST client for python 3.5+, supports sync (with requests) and asyncio (with aiohttp) requests
+Simple REST client for python 3.6+, supports sync (with requests) and asyncio (with aiohttp) requests
 
 
 Contents

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,4 +5,4 @@ Install the latest stable release via pip::
 
     pip install simple-rest-client
 
-python-simple-rest-client runs with `Python 3.5+ <https://travis-ci.org/allisson/python-simple-rest-client>`_ .
+python-simple-rest-client runs with `Python 3.6+ <https://travis-ci.org/allisson/python-simple-rest-client>`_ .

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Libraries",
     ],
     keywords="rest client http asyncio",

--- a/simple_rest_client/decorators.py
+++ b/simple_rest_client/decorators.py
@@ -27,10 +27,7 @@ def handle_request_error(f):
         try:
             response = f(*args, **kwargs)
         except (
-            exceptions.ReadTimeout,
-            exceptions.ReadTimeout,
-            exceptions.WriteTimeout,
-            exceptions.PoolTimeout,
+            exceptions.Timeout,
         ) as exc:
             logger.exception(exc)
             raise ClientConnectionError() from exc

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -54,7 +54,7 @@ def test_validate_response_client_error(status_code, response_kwargs):
 
 @pytest.mark.parametrize(
     "side_effect",
-    (exceptions.ReadTimeout, exceptions.ReadTimeout, exceptions.WriteTimeout, exceptions.PoolTimeout),
+    (exceptions.ConnectTimeout, exceptions.ReadTimeout, exceptions.WriteTimeout, exceptions.PoolTimeout),
 )
 def test_handle_request_error_exceptions(side_effect):
     wrapped = mock.Mock(side_effect=side_effect)


### PR DESCRIPTION
I've noticed that ReadTimeout was twice in the list of Timeout exceptions, and since httpx has a base Timeout exception, I though it would make sense to just check for that.

Unless you didn't want to consider ConnectTimeout for the ClientConnectionError scenario.. then you can dismiss this PR :)

Also added python 3.8 to travis and raised the references to python 3.6+ where I found it mentioning 3.5.

Thanks for the project :)