### PR TITLE
Locking httpx version below 0.8.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+1.0.2
+~~~~~
+
+* Locking httpx version below 0.8.0 (thanks @patcon).
+
 1.0.1
 ~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 python-status>=1.0.1
-httpx>=0.7.4
+httpx<0.8.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with codecs.open(os.path.join(here, "CHANGES.rst"), encoding="utf-8") as f:
     changelog = f.read()
 
 
-install_requirements = ["python-status>=1.0.1", "httpx>=0.7.4"]
+install_requirements = ["python-status>=1.0.1", "httpx<0.8.0"]
 tests_requirements = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "coveralls"]
 
 


### PR DESCRIPTION
Fixes https://github.com/allisson/python-simple-rest-client/issues/25