### PR TITLE
fix: preserve resource_name in URLs without the attribute name mangling

### DIFF
--- a/simple_rest_client/api.py
+++ b/simple_rest_client/api.py
@@ -35,11 +35,10 @@ class API:
         json_encode_body=None,
         ssl_verify=None,
     ):
-        resource_valid_name = self.correct_attribute_name(resource_name)
         resource_class = resource_class or Resource
         resource = resource_class(
             api_root_url=api_root_url if api_root_url is not None else self.api_root_url,
-            resource_name=resource_valid_name,
+            resource_name=resource_name,
             params=params if params is not None else self.params,
             headers=headers if headers is not None else self.headers,
             timeout=timeout if timeout is not None else self.timeout,
@@ -47,7 +46,8 @@ class API:
             json_encode_body=json_encode_body if json_encode_body is not None else self.json_encode_body,
             ssl_verify=ssl_verify if ssl_verify is not None else self.ssl_verify,
         )
-        self._resources[resource_valid_name] = resource
+        self._resources[resource_name] = resource
+        resource_valid_name = self.correct_attribute_name(resource_name)
         setattr(self, resource_valid_name, resource)
 
     def get_resource_list(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,7 +45,8 @@ def test_api_resource_valid_name(resource_name, resource_valid_name, api):
     api.add_resource(resource_name=resource_name)
     resource = getattr(api, resource_valid_name)
     assert isinstance(resource, Resource)
-    assert resource_valid_name in api._resources
+    assert resource_name in api._resources
+    assert resource.get_action_full_url('list') == f'{api.api_root_url}{resource_name}'
 
 
 def test_api_add_resource_with_other_resource_class(api, reqres_resource):


### PR DESCRIPTION
Since `resource_name` maps directly to the URL, it should not be changed
before creating the resource.

The name should only be fixed for the attribute name that will be used
to attach it to the API instance.

Fixes #32.